### PR TITLE
Ability to customize user for authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ end
 
 The `Bodyguard.Controller` module contains helper functions designed to provide authorization in controller actions. You should probably import it in `web.ex` so it is available to all controllers.
 
-The user to authorize is retrieved from `conn.assigns[:current_user]`.
+The user to authorize is retrieved from `conn.assigns[:current_user]`. You can [customize model to authorization](### Customize user fetching)
 
 * `authorize/3` returns the tuple `{:ok, conn}` on success, and `{:error, :unauthorized}` on failure.
 * `authorize!/3` returns a modified `conn` on success, and will raise `Bodyguard.NotAuthorizedError` on failure. By default, this exception will cause Plug to return HTTP status code 403 Forbidden.
@@ -268,6 +268,17 @@ end
 What if you have a Phoenix controller that doesn't correspond to one particular resource? Or, maybe you just want to customize how that controller's actions are locked down.
 
 Try creating a policy for the controller itself. `MyApp.FooController.Policy` is completely acceptable.
+
+
+### Customize user fetching
+
+You can customize `current_user` by specifying the key as atom or function in application:
+
+```elixir
+# config.exs
+config :bodyguard, :current_user, :current_token # It will use `conn.assigns[:current_token]` for authorization
+config :bodyguard, :current_user, fn(conn) -> Enum.random([true, false]) end # Let make user furious, `true` or `false` will use for authorization here
+```
 
 ## Not What You're Looking For?
 

--- a/lib/bodyguard/controller.ex
+++ b/lib/bodyguard/controller.ex
@@ -120,8 +120,13 @@ defmodule Bodyguard.Controller do
 
 
   defp get_current_user(conn) do
-    key = Application.get_env(:bodyguard, :current_user, :current_user)
-    conn.assigns[key]
+    auth_key = Application.get_env(:bodyguard, :current_user, :current_user)
+
+    if is_atom(auth_key) do
+      conn.assigns[auth_key]
+    else
+      auth_key.(conn)
+    end
   end
 
   defp get_action(conn) do


### PR DESCRIPTION
I found that `bodyguard` doesn't fit for my application, and there is possibility it wouldn't make some users happy because of authorization method (i.e. I don't use `current_user` in my app).

I decided to implement ability to pass anonymous function here, so it brings big flexibility for developers. I tested this code at `dev`, everything is working fine.