### PR TITLE
Add option for Bodyguard loading current user from function

### DIFF
--- a/lib/bodyguard/controller.ex
+++ b/lib/bodyguard/controller.ex
@@ -185,11 +185,25 @@ defmodule Bodyguard.Controller do
   with the `:current_user` configuration option:
 
       config :bodyguard, current_user: :my_custom_assign_key
+
+  Current user may also be retrieved via function using a module-function tuple:
+
+      config :bodyguard, current_user: {Guardian.Plug, :current_resource}
   """
   @spec get_current_user(Plug.Conn.t) :: Plug.Conn.t
   def get_current_user(conn) do
     key = Application.get_env(:bodyguard, :current_user, :current_user)
+    get_current_user(conn, key)
+  end
+
+  # Private
+
+  defp get_current_user(conn, key) when is_atom(key) do
     conn.assigns[key]
+  end
+
+  defp get_current_user(conn, {mod, fun}) do
+    apply(mod, fun, [conn])
   end
 
   @doc """

--- a/test/bodyguard/controller_test.exs
+++ b/test/bodyguard/controller_test.exs
@@ -162,4 +162,25 @@ defmodule Policy.HelpersTest do
     assert Bodyguard.Controller.authorize(conn, struct) == {:error, :because_i_said_so}
     assert Bodyguard.Controller.authorize(conn, struct, policy: MockStruct.Policy)
   end
+
+  test "current user from keyword", %{conn: conn} do
+    Application.put_env(:bodyguard, :current_user, :bodyguard_test_user)
+
+    user = %{name: "test-user"}
+    conn = Plug.Conn.assign(conn, :bodyguard_test_user, user)
+    assert Bodyguard.Controller.get_current_user(conn) == user
+  end
+
+  test "current user using a function", %{conn: conn} do
+    defmodule TestLoader do
+      def current_resource(conn) do
+        conn.private[:bodyguard_test_user]
+      end
+    end
+    Application.put_env(:bodyguard, :current_user, {TestLoader, :current_resource})
+
+    user = %{name: "test-user"}
+    conn = Plug.Conn.put_private(conn, :bodyguard_test_user, user)
+    assert Bodyguard.Controller.get_current_user(conn) == user
+  end
 end


### PR DESCRIPTION
As discussed in https://github.com/schrockwell/bodyguard/pull/10#issuecomment-251440483.

As per use case I think it would be much nicer to use Guardian's resource directly instead of having to use a separate plug in the middle of Guardian and Bodyguard.