### PR TITLE
WIP: Add macro for incorporating auth checks in context 30

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ assert Bodyguard.permit(MyApp.Blog, :successful_action, user)
 refute Bodyguard.permit(MyApp.Blog, :failing_action, user)
 
 error = assert_raise Bodyguard.NotAuthorizedError, fun ->
-  Bodyguard.permit(MyApp.Blog, :failing_action, user)
+  Bodyguard.permit!(MyApp.Blog, :failing_action, user)
 end
 assert %{status: 403, message: "not authorized"} = error
 ```

--- a/lib/bodyguard/policy.ex
+++ b/lib/bodyguard/policy.ex
@@ -89,7 +89,6 @@ defmodule Bodyguard.Policy do
       )
       map = Enum.zip(unquote(names), values) |> Enum.into(%{})
       with :ok <- authorize(unquote(func_name), var!(user), map) do
-        # unquote(noauth_func_name)(unquote(func_args))
         unquote(body)
       end
     end

--- a/lib/bodyguard/policy.ex
+++ b/lib/bodyguard/policy.ex
@@ -62,6 +62,9 @@ defmodule Bodyguard.Policy do
     {noauth_func_name, noauth_func}
   end
 
+  defp create_authed_method(func_name, line, nil) do
+    {func_name, line, [{:user, line, nil}]}
+  end
   defp create_authed_method(func_name, line, func_args) do
     auth_args = [{:user, line, nil} | func_args]
     {func_name, line, auth_args}

--- a/lib/bodyguard/policy.ex
+++ b/lib/bodyguard/policy.ex
@@ -72,7 +72,6 @@ defmodule Bodyguard.Policy do
     auth_args = [{:user, line, nil} | func_args]
     auth_func = {func_name, line, auth_args}
 
-
     names = func_args |> get_args |> Enum.map(&elem(&1, 0))
     authed = quote do
       # not 100% sure I need this

--- a/lib/bodyguard/policy.ex
+++ b/lib/bodyguard/policy.ex
@@ -54,42 +54,58 @@ defmodule Bodyguard.Policy do
   #     apply(func, [args])
   #   end
   # end
-  def get_args(args), do: do_get_args(args, [])
-  def do_get_args([], acc), do: acc
-  def do_get_args([{_, _, context} = var | rest], acc) when not is_list(context) do
-    acc = [var | acc]
-    do_get_args(rest, acc)
+
+  def get_args(args), do: do_get_args(Enum.reverse(args), [])
+  defp do_get_args([], acc), do: acc
+  defp do_get_args([{_, _, context} = var | rest], acc) when not is_list(context) do
+    do_get_args(rest, [var | acc])
   end
-  def do_get_args([ {_, _, context} | rest], acc) when is_list(context) do
+  defp do_get_args([ {_, _, context} | rest], acc) when is_list(context) do
     acc = do_get_args(context, acc)
     do_get_args(rest, acc)
   end
-  def do_get_args(_, acc), do: acc
+  defp do_get_args([ {_, {_, _, context} = var} | rest], acc) when not is_list(context) do
+    acc = [var | acc]
+    do_get_args(rest, acc)
+  end
+  defp do_get_args([atom_val], acc) when is_atom(atom_val), do: acc
+  defp do_get_args(hmm, acc) do
+    IO.inspect "PROBABLE Problem ----"
+    IO.inspect hmm
+    acc
+  end
 
   defmacro defauth({func_name,line,func_args}, [do: body]) do
+    IO.inspect "============================"
+    IO.inspect "Macro Scope"
+    IO.inspect func_args
     noauth_func_name = ("__" <> Atom.to_string(func_name) <> "__") |> String.to_atom
     noauth_func = {noauth_func_name, line, func_args}
     auth_args = [{:user, line, nil} | func_args]
     auth_func = {func_name, line, auth_args}
 
     names = func_args |> get_args |> Enum.map(&elem(&1, 0))
+
     authed = quote do
-      # not 100% sure I need this
       values = unquote(
         func_args
         |> get_args
         |> Enum.map(fn arg ->  quote do
-            # allow to access a value at runtime knowing the name
-            # elixir macros are hygienic so it's necessary to mark it
-            # explicitly
             var!(unquote(arg))
           end
         end)
       )
       map = Enum.zip(unquote(names), values) |> Enum.into(%{})
-      with :ok <- authorize(unquote(func_name), var!(user), map) do
-        unquote(body)
-      end
+      args = unquote(names)
+        |> Enum.reverse
+        |> Enum.reduce([], &([Keyword.get(binding(), &1) | &2]))
+      auth_apply(__MODULE__, unquote(func_name), unquote(noauth_func_name), var!(user), map, args)
+      # with :ok <- authorize(unquote(func_name), var!(user), map) do
+      #   args = unquote(names)
+      #     |> Enum.reverse
+      #     |> Enum.reduce([], &([Keyword.get(binding(), &1) | &2]))
+      #   apply(__MODULE__, unquote(noauth_func_name), args)
+      # end
     end
 
     quote do
@@ -109,12 +125,11 @@ defmodule Bodyguard.Policy do
   #   # Do stuff
   # end
 
-  # def auth_apply(action, real_action, user, params) do
-  #   with :ok <- authorize(action, user, params) do
-  #     apply(real_action, params)
-  #     # __create_user__(params)
-  #   end
-  # end
+  def auth_apply(mod, action, real_action, user, param_map, param_list) do
+    with :ok <- apply(mod, :authorize, [action, user, param_map]) do
+      apply(mod, real_action, param_list)
+    end
+  end
 
   @doc false
   defmacro __using__(opts) do

--- a/test/bodyguard/policy_test.exs
+++ b/test/bodyguard/policy_test.exs
@@ -44,34 +44,37 @@ defmodule PolicyTest do
     context = TestDefauthContext
     user = %TestDefauthContext.User{allow: true}
 
-    assert :succeed = context.succeed(user)
-    assert :override = context.succeed(user, :override)
-    assert :result = context.succeed(user, %{result: :result})
-    assert :var2 = context.succeed(user, :var1, :var2, :var3)
-    assert :var2 = context.succeed(user, :var1, %{var2: :var2}, :var3)
+    assert :succeed                = context.succeed(user)
+    assert :override               = context.succeed(user, :override)
+    assert :result                 = context.succeed(user, %{result: :result})
+    assert :var2                   = context.succeed(user, :var1, :var2, :var3)
+    assert :var2                   = context.succeed(user, :var1, %{var2: :var2}, :var3)
     assert {:error, :unauthorized} = context.fail(user, %{})
+    assert :succeed                = context.noargs(user)
   end
 
   test "testability skipping auth" do
     context = TestDefauthContext
 
-    assert :succeed = context.__succeed__()
+    assert :succeed  = context.__succeed__()
     assert :override = context.__succeed__(:override)
-    assert :result = context.__succeed__(%{result: :result})
-    assert :var2 = context.__succeed__(:var1, :var2, :var3)
-    assert :var2 = context.__succeed__(:var1, %{var2: :var2}, :var3)
-    assert :fail = context.__fail__(%{})
+    assert :result   = context.__succeed__(%{result: :result})
+    assert :var2     = context.__succeed__(:var1, :var2, :var3)
+    assert :var2     = context.__succeed__(:var1, %{var2: :var2}, :var3)
+    assert :fail     = context.__fail__(%{})
+    assert :succeed  = context.__noargs__()
   end
 
   test "implicit authorization with defauth and deferral policy" do
     context = TestDefauthDeferralContext
     user = %TestDefauthDeferralContext.User{allow: true}
 
-    assert :succeed = context.succeed(user)
-    assert :override = context.succeed(user, :override)
-    assert :result = context.succeed(user, %{result: :result})
-    assert :var2 = context.succeed(user, :var1, :var2, :var3)
-    assert :var2 = context.succeed(user, :var1, %{var2: :var2}, :var3)
+    assert :succeed                = context.succeed(user)
+    assert :override               = context.succeed(user, :override)
+    assert :result                 = context.succeed(user, %{result: :result})
+    assert :var2                   = context.succeed(user, :var1, :var2, :var3)
+    assert :var2                   = context.succeed(user, :var1, %{var2: :var2}, :var3)
     assert {:error, :unauthorized} = context.fail(user, %{})
+    assert :succeed                = context.noargs(user)
   end
 end

--- a/test/bodyguard/policy_test.exs
+++ b/test/bodyguard/policy_test.exs
@@ -52,6 +52,17 @@ defmodule PolicyTest do
     assert {:error, :unauthorized} = context.fail(user, %{})
   end
 
+  test "testability skipping auth" do
+    context = TestDefauthContext
+
+    assert :succeed = context.__succeed__()
+    assert :override = context.__succeed__(:override)
+    assert :result = context.__succeed__(%{result: :result})
+    assert :var2 = context.__succeed__(:var1, :var2, :var3)
+    assert :var2 = context.__succeed__(:var1, %{var2: :var2}, :var3)
+    assert :fail = context.__fail__(%{})
+  end
+
   test "implicit authorization with defauth and deferral policy" do
     context = TestDefauthDeferralContext
     user = %TestDefauthDeferralContext.User{allow: true}

--- a/test/bodyguard/policy_test.exs
+++ b/test/bodyguard/policy_test.exs
@@ -39,4 +39,21 @@ defmodule PolicyTest do
     assert :ok                     = TestDeferralContext.authorize(:succeed, user)
     assert {:error, :unauthorized} = TestDeferralContext.authorize(:fail, user)
   end
+
+  test "implicit authorization with defauth" do
+    context = TestDefauthContext
+    user = %TestDefauthContext.User{allow: true}
+
+    assert :succeed = context.succeed(user)
+    assert :override = context.succeed(user, :override)
+    assert :result = context.succeed(user, %{result: :result})
+    assert :var2 = context.succeed(user, :var1, :var2, :var3)
+    assert :var2 = context.succeed(user, :var1, %{var2: :var2}, :var3)
+    assert {:error, :unauthorized} = context.fail(user, %{})
+  end
+
+  # test "implicit authorization with defauth in separate policy", %{user: user} do
+  #   assert :succeed = TestDeferralContext.succeed(user, %{})
+  #   refute {:error, :unauthorized} = TestDeferralContext.fail(user, %{})
+  # end
 end

--- a/test/bodyguard/policy_test.exs
+++ b/test/bodyguard/policy_test.exs
@@ -52,8 +52,15 @@ defmodule PolicyTest do
     assert {:error, :unauthorized} = context.fail(user, %{})
   end
 
-  # test "implicit authorization with defauth in separate policy", %{user: user} do
-  #   assert :succeed = TestDeferralContext.succeed(user, %{})
-  #   refute {:error, :unauthorized} = TestDeferralContext.fail(user, %{})
-  # end
+  test "implicit authorization with defauth and deferral policy" do
+    context = TestDefauthDeferralContext
+    user = %TestDefauthDeferralContext.User{allow: true}
+
+    assert :succeed = context.succeed(user)
+    assert :override = context.succeed(user, :override)
+    assert :result = context.succeed(user, %{result: :result})
+    assert :var2 = context.succeed(user, :var1, :var2, :var3)
+    assert :var2 = context.succeed(user, :var1, %{var2: :var2}, :var3)
+    assert {:error, :unauthorized} = context.fail(user, %{})
+  end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -66,6 +66,10 @@ defmodule TestDefauthContext do
     {:error, :unauthorized}
   end
 
+  defauth noargs do
+    :succeed
+  end
+
   defauth fail(_params) do
     :fail
   end
@@ -97,6 +101,10 @@ defmodule TestDefauthDeferralContext do
 
   defauth fail(_params) do
     :fail
+  end
+
+  defauth noargs do
+    :succeed
   end
 
   defauth succeed(%{result: result}) do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,10 +1,10 @@
 defmodule TestContext do
-  @behaviour Bodyguard.Policy
+  use Bodyguard.Policy
 
   defmodule User do
     defstruct [allow: true]
   end
-  
+
   def authorize(action, user, params \\ %{})
 
   def authorize(_, %User{allow: false}, _params) do
@@ -22,6 +22,70 @@ defmodule TestContext do
   def authorize(_action, _user, _params) do
     :ok
   end
+end
+
+defmodule TestDefauthContext do
+  use Bodyguard.Policy
+
+  defmodule User do
+    defstruct [allow: true]
+  end
+
+  def authorize(action, user, params \\ %{})
+
+  # mapify params, and send to the authorize method
+  def authorize(:fail, _user, _params) do
+    {:error, :unauthorized}
+  end
+
+  def authorize(_, %User{allow: true}, %{var2: :var2}) do
+    IO.inspect "var2 = var2"
+    :ok
+  end
+  def authorize(_, %User{allow: true}, %{var2: %{var2: :var2}}) do
+    IO.inspect "var2 = var2"
+    :ok
+  end
+
+  def authorize(_, %User{allow: true}, %{var2: _}) do
+    IO.inspect "var2 != var2"
+    {:error, :unauthorized}
+  end
+
+  def authorize(_, %User{allow: false}, _params) do
+    IO.inspect "User allow false"
+    {:error, :unauthorized}
+  end
+
+  def authorize(_, %User{allow: true}, _params) do
+    IO.inspect "User allow true"
+    :ok
+  end
+
+  def authorize(_action, _user, _params) do
+    {:error, :unauthorized}
+  end
+
+  defauth fail(_params) do
+    :fail
+  end
+
+  defauth succeed(%{result: result}) do
+    result
+  end
+
+  defauth succeed(result \\ :succeed) do
+    result
+  end
+
+  defauth succeed(_var1, %{var2: var2}, _var3) do
+    var2
+  end
+
+  defauth succeed(_var1, var2, _var3) do
+    var2
+  end
+
 end
 
 defmodule TestDeferralContext do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -88,6 +88,73 @@ defmodule TestDefauthContext do
 
 end
 
+defmodule TestDefauthDeferralContext do
+  use Bodyguard.Policy, policy: TestDefauthDeferralContext.Policy
+
+  defmodule User do
+    defstruct [allow: true]
+  end
+
+  defauth fail(_params) do
+    :fail
+  end
+
+  defauth succeed(%{result: result}) do
+    result
+  end
+
+  defauth succeed(result \\ :succeed) do
+    result
+  end
+
+  defauth succeed(_var1, %{var2: var2}, _var3) do
+    var2
+  end
+
+  defauth succeed(_var1, var2, _var3) do
+    var2
+  end
+end
+
+defmodule TestDefauthDeferralContext.Policy do
+  alias TestDefauthDeferralContext.User
+
+  def authorize(action, user, params \\ %{})
+
+  # mapify params, and send to the authorize method
+  def authorize(:fail, _user, _params) do
+    {:error, :unauthorized}
+  end
+
+  def authorize(_, %User{allow: true}, %{var2: :var2}) do
+    IO.inspect "var2 = var2"
+    :ok
+  end
+  def authorize(_, %User{allow: true}, %{var2: %{var2: :var2}}) do
+    IO.inspect "var2 = var2"
+    :ok
+  end
+
+  def authorize(_, %User{allow: true}, %{var2: _}) do
+    IO.inspect "var2 != var2"
+    {:error, :unauthorized}
+  end
+
+  def authorize(_, %User{allow: false}, _params) do
+    IO.inspect "User allow false"
+    {:error, :unauthorized}
+  end
+
+  def authorize(_, %User{allow: true}, _params) do
+    IO.inspect "User allow true"
+    :ok
+  end
+
+  def authorize(_action, _user, _params) do
+    {:error, :unauthorized}
+  end
+end
+
 defmodule TestDeferralContext do
   use Bodyguard.Policy, policy: TestDeferralContext.Policy
 end


### PR DESCRIPTION
This is NOT done. My kids are up and so I'm done for the day. Just posting in case you wanted to take a look and see if things are going the way you expected.

Open Issues
- [x] Code is so so ugly
- [x] I haven't figured out how to make the authorized version just call the unauthorized version. Right now I'm duplicating the block in the AST, which will slow down compilation
- [x] Make auth_apply overridable  (https://elixirforum.com/t/behaviours-defoverridable-and-implementations/3338)
- [ ] Tests are ugly
- [ ] No updates to the docs yet
- [ ] Clean up commit history

That said, it appears to be working.  There are some tests to verify functionality with internal and external policies, and also tests to ensure the underlying methods respond as expected.  

The reason the tests look the way they do, is because I needed to var! the args being passed to authorize, but that call was getting confused when the method signature had default values (\\) or pattern matching.  So it seems that I need to recursively walk the args tree to find the values to expose.  So the bizarre method signatures are there to exercise that code.

I think my next step will be to clean up the code to the point it's up to snuff with the rest of what you have, and then if I'm still struggling w/ the dupe AST's doesn't present itself, I'll post a question on elixirforum, while working on the docs.  