### PR TITLE
Change recommendation to perform authorization within contexts

### DIFF
--- a/lib/bodyguard.ex
+++ b/lib/bodyguard.ex
@@ -3,8 +3,30 @@ defmodule Bodyguard do
   Authorize actions at the boundary of a context
 
   Please see the [README](readme.html).
+
+  TODO: Add documentation for `use Bodyguard`
   """
-  
+
+  @doc false
+  defmacro __using__(opts) do
+    quote bind_quoted: [opts: opts] do
+      use Bodyguard.Policy, opts
+      import Bodyguard, only: [scope: 3]
+
+      def permit(action, user, params \\ []) do
+        Bodyguard.permit(__MODULE__, action, user, params)
+      end
+
+      def permit?(action, user, params \\ []) do
+        Bodyguard.permit?(__MODULE__, action, user, params)
+      end
+
+      def permit!(action, user, params \\ []) do
+        Bodyguard.permit!(__MODULE__, action, user, params)
+      end
+    end
+  end
+
   @type opts :: keyword
 
   @doc """

--- a/test/bodyguard/policy_test.exs
+++ b/test/bodyguard/policy_test.exs
@@ -42,4 +42,19 @@ defmodule PolicyTest do
     assert :ok                     = Bodyguard.permit(TestDeferralContext, :succeed, user)
     assert {:error, :unauthorized} = Bodyguard.permit(TestDeferralContext, :fail, user)
   end
+
+  test "using the permit context helper directly", %{context: context, user: user} do
+    assert :ok = context.permit(:action, user)
+    assert {:error, :unauthorized} = context.permit(:fail, user)
+
+    assert context.permit?(:action, user)
+    refute context.permit?(:fail, user)
+
+    assert_raise Bodyguard.NotAuthorizedError, fn ->
+      context.permit!(:fail, user)
+    end
+
+    assert :ok = TestDeferralContext.permit(:succeed, user)
+    assert {:error, :unauthorized} = TestDeferralContext.permit(:fail, user)
+  end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,5 +1,5 @@
 defmodule TestContext do
-  @behaviour Bodyguard.Policy
+  use Bodyguard
 
   defmodule User do
     defstruct [allow: true]
@@ -37,7 +37,7 @@ defmodule TestContext do
 end
 
 defmodule TestDeferralContext do
-  use Bodyguard.Policy, policy: TestDeferralContext.Policy
+  use Bodyguard, policy: TestDeferralContext.Policy
 end
 
 defmodule TestDeferralContext.Policy do


### PR DESCRIPTION
- [x] Add `use Bodyguard` for contexts to encapsulate this idea
- [x] Add tests
- [x] Keep backwards-compatability (public `Bodyguard.permit/4` helpers, public `authorize/3` callbacks, etc.)
- [x] Add readme notes on v2.1 -> v2.2 changes
- [ ] Update docs