### PR TITLE
Support returning a resource from authorize

### DIFF
--- a/lib/bodyguard.ex
+++ b/lib/bodyguard.ex
@@ -165,6 +165,7 @@ defmodule Bodyguard do
   # Coerce auth results
   defp resolve_result(true), do: :ok
   defp resolve_result(:ok), do: :ok
+  defp resolve_result({:ok, resource}), do: {:ok, resource}
   defp resolve_result(false), do: {:error, :unauthorized}
   defp resolve_result(:error), do: {:error, :unauthorized}
   defp resolve_result({:error, reason}), do: {:error, reason}

--- a/lib/bodyguard/policy.ex
+++ b/lib/bodyguard/policy.ex
@@ -11,7 +11,7 @@ defmodule Bodyguard.Policy do
         @behaviour Bodyguard.Policy
 
         def authorize(action, user, params) do
-          # Return :ok or true to permit
+          # Return :ok {:ok, resource}, or true to permit
           # Return :error, {:error, reason}, or false to deny
         end
       end
@@ -37,12 +37,12 @@ defmodule Bodyguard.Policy do
 
   """
 
-  @type auth_result :: :ok | :error | {:error, reason :: any} | true | false
+  @type auth_result :: :ok | {:ok, resource :: any} | :error | {:error, reason :: any} | true | false
 
   @doc """
   Callback to authorize a user's action.
 
-  To permit an action, return `:ok` or `true`. To deny, return `:error`,
+  To permit an action, return `:ok`, `{:ok, resource}`, or `true`. To deny, return `:error`,
   `{:error, reason}`, or `false`.
 
   The `action` is whatever user-specified contextual action is being authorized.

--- a/test/bodyguard/policy_test.exs
+++ b/test/bodyguard/policy_test.exs
@@ -14,6 +14,7 @@ defmodule PolicyTest do
   test "authorizing via helper", %{context: context, user: user} do
     assert :ok = Bodyguard.permit(context, :action, user)
     assert :ok = Bodyguard.permit(context, :ok_boolean, user)
+    assert {:ok, resource} = Bodyguard.permit(context, :ok_with_resource, user)    
     assert {:error, :unauthorized} = Bodyguard.permit(context, :fail, user)
 
     assert {:error, %{key: :value}} =

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -23,6 +23,10 @@ defmodule TestContext do
     true
   end
 
+  def authorize(:ok_with_resource, _user, _params) do
+    {:ok, %{id: 1, name: "foo"}}
+  end
+
   def authorize(:fail_boolean, _user, _params) do
     false
   end


### PR DESCRIPTION
Adds support for returning a resource from `authorize/3`. I'm not sure if this is zany or not.

Frequently when I am working with controller _show_ actions I find that
I end up calling my phoenix context from my policy to verify ownership
of a resource:

```elixir
def authorize(:show_post, %User{id: user_id}, %{id: post_id}) do
  case Posts.get_post(post_id) do
    {:ok, post} -> post.user_id == user_id
    _ -> :error
  end
end
```

Subsequenctly I end up calling that context again in my controller once
Bodyguard has returned `true` or `:ok`.

It would be nice if bodyguard supported returning a resource with the
response so for actions like _show_ we can do efficient returns.

```elixir
  def authorize(:show_post, %User{id: user_id}, %{id: post_id}) do
    with {:ok, post} <- Posts.get_post(post_id),
         true <- post.user_id == user_id, do: {:ok, post}
    else
      _ -> :error
    end
  end
```

And then in the controller:

```elixir
  def show(conn, post_params)
    case Bodyguard.permit(MyApp.Blog, :show_post, conn.assigns.current_user, post_params) do
      {:ok, post} -> {:ok, post}
      error -> error
    end
  end
```