### PR TITLE
Fix typos in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,8 +204,8 @@ Testing is pretty straightforward – use the `Bodyguard` top-level API.
 assert :ok == Bodyguard.permit(MyApp.Blog, :successful_action, user)
 assert {:error, :unauthorized} == Bodyguard.permit(MyApp.Blog, :failing_action, user)
 
-assert Bodyguard.permit(MyApp.Blog, :successful_action, user)
-refute Bodyguard.permit(MyApp.Blog, :failing_action, user)
+assert Bodyguard.permit?(MyApp.Blog, :successful_action, user)
+refute Bodyguard.permit?(MyApp.Blog, :failing_action, user)
 
 error = assert_raise Bodyguard.NotAuthorizedError, fun ->
   Bodyguard.permit(MyApp.Blog, :failing_action, user)


### PR DESCRIPTION
This corrects a coupe of typos in README.md so that functions documented
in testing section return booleans as advertised.

Previously there was the following (no question marks):

```ex
assert Bodyguard.permit(MyApp.Blog, :successful_action, user)
refute Bodyguard.permit(MyApp.Blog, :failing_action, user)
```

`Bodyguard.permit(MyApp.Blog, :failing_action, user)` returns `{:error,
:unauthorized}` not `false`, so this test would fail.