### PR TITLE
Implement actions/1 for Plug.Exception protocol

### DIFF
--- a/lib/bodyguard/not_authorized_error.ex
+++ b/lib/bodyguard/not_authorized_error.ex
@@ -8,4 +8,5 @@ end
 defimpl Plug.Exception, for: Bodyguard.NotAuthorizedError do
   # Forbidden
   def status(exception), do: exception.status || 403
+  def actions(_exception), do: []
 end


### PR DESCRIPTION
There's not much value we can provide with `actions/1` here, so we can just respond with empty list.

(This is what [Phoenix does](https://github.com/phoenixframework/phoenix/blob/25ef2660bbd3eedcc267236a22d957c0452eb3fa/lib/phoenix/exceptions.ex#L67-L70))