### PR TITLE
Support `action` as String.t

### DIFF
--- a/lib/bodyguard.ex
+++ b/lib/bodyguard.ex
@@ -5,6 +5,7 @@ defmodule Bodyguard do
   Please see the [README](readme.html).
   """
 
+  @type action :: atom | String.t
   @type opts :: keyword | %{optional(atom) => any}
 
   @doc """
@@ -16,7 +17,7 @@ defmodule Bodyguard do
   to the `c:Bodyguard.Policy.authorize/3` callback. Otherwise, `params` is not
   changed.
   """
-  @spec permit(policy :: module, action :: atom, user :: any, params :: any) ::
+  @spec permit(policy :: module, action :: action, user :: any, params :: any) ::
           :ok | {:error, any} | no_return()
   def permit(policy, action, user, params \\ []) do
     params = try_to_mapify(params)
@@ -42,7 +43,7 @@ defmodule Bodyguard do
   * `error_status` – the HTTP status code to raise with the error (default 403)
   """
 
-  @spec permit!(policy :: module, action :: atom, user :: any, params :: any, opts :: opts) ::
+  @spec permit!(policy :: module, action :: action, user :: any, params :: any, opts :: opts) ::
           :ok | no_return()
   def permit!(policy, action, user, params \\ [], opts \\ []) do
     params = try_to_mapify(params)
@@ -68,7 +69,7 @@ defmodule Bodyguard do
   @doc """
   The same as `permit/4`, but returns a boolean.
   """
-  @spec permit?(policy :: module, action :: atom, user :: any, params :: any) :: boolean
+  @spec permit?(policy :: module, action :: action, user :: any, params :: any) :: boolean
   def permit?(policy, action, user, params \\ []) do
     case permit(policy, action, user, params) do
       :ok -> true

--- a/lib/bodyguard/policy.ex
+++ b/lib/bodyguard/policy.ex
@@ -37,6 +37,7 @@ defmodule Bodyguard.Policy do
 
   """
 
+  @type action :: atom | String.t
   @type auth_result :: :ok | :error | {:error, reason :: any} | true | false
 
   @doc """
@@ -49,7 +50,7 @@ defmodule Bodyguard.Policy do
   It bears no intrinsic relationship to a controller action, and instead should
   share a name with a particular function on the context.
   """
-  @callback authorize(action :: atom, user :: any, params :: %{atom => any} | any) :: auth_result
+  @callback authorize(action :: action, user :: any, params :: %{atom => any} | any) :: auth_result
 
   @doc false
   defmacro __using__(opts) do


### PR DESCRIPTION
There's no change in the internal behavior or design, actually it does work with both atom and string.

This change is to support environments where the action is defined as string, for eg, when that action is tied to permissions on a DB.