### PR TITLE
Misc doc changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# Changelog
+
 ### Legend
 
 * **Fix:** no API change; fixing code to intended behavior
@@ -5,54 +7,53 @@
 * **Deprecation:** addition to API; old behavior maintained with deprecation warning
 * **Change:** breaking change to API
 
-# Bodyguard Changelog
-
-## v2.4.0
+## v2.4.0 - 2019-08-04
 
 * **Addition:** Adding ability to specify `{module, function}` for plug's value getters
 * **Addition:** Adding default config options for Authorize plug
 
-## v2.3.0
+## v2.3.0 - 2019-07-26
 
-* **Addition:** Adding ability to specify function for plug's `:params` option  
+* **Addition:** Adding ability to specify function for plug's `:params` option
 * **Addition:** Adding `:default_error` config option (defaults to `:unauthorized`)
 * **Fix:** Conforming to `init/1` return typespec for older versions of Plug
 
-## v2.2.4
+## v2.2.4 - 2019-07-15
 
 * **Fix:** #58 Replacing deprecated Phoenix render function
 
-## v2.2.3
+## v2.2.3 - 2018-11-21
 
 * **Fix:** Adding support for Ecto 3 queries
 
-## v2.2.2
+## v2.2.2 - 2018-01-28
 
 * **Fix:** Fixing typespecs #43
 
-## v2.2.1
+## v2.2.1 - 2017-12-20
 
 * **Addition:** Adding ability to specify function for plug's `:action` option f4033852a8ad2bbd48c54766086d7dd2e8dae8f8
 
-## v2.2.0
+## v2.2.0 - 2017-11-26
 
 * **Deprecation:** Moving user-specified options to explicit `opts` argument #40
 
-## v2.1.2
+## v2.1.2 - 2017-08-05
+
 * **Deprecation:** Deprecating `use Bodyguard.Policy` and `use Bodyguard.Schema` in favor of straight `defdelegate` dc56221fedfa071f97fba760ff84e591349518e0
 
-## v2.1.1
+## v2.1.1 - 2017-07-26
 
 * **Fix:** Fixing typespecs #35
 
-## v2.1.0
+## v2.1.0 - 2017-07-22
 
 * **Addition:** Allowing boolean results from `authorize/3` callbacks #32
 
-## v2.0.1
+## v2.0.1 - 2017-07-05
 
 * **Fix:** Fixing handling of plug's `:user` option #28
 
-## v2.0.0
+## v2.0.0 - 2017-06-30
 
 * **Change:** Using new context-based API

--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-# Bodyguard [![Hex Version](https://img.shields.io/hexpm/v/bodyguard.svg)](https://hex.pm/packages/bodyguard) [![docs](https://img.shields.io/badge/docs-hexpm-blue.svg)](https://hexdocs.pm/bodyguard/)
+# Bodyguard
+
+[![Module Version](https://img.shields.io/hexpm/v/bodyguard.svg)](https://hex.pm/packages/bodyguard)
+[![Hex Docs](https://img.shields.io/badge/hex-docs-lightgreen.svg)](https://hexdocs.pm/bodyguard/)
+[![Total Download](https://img.shields.io/hexpm/dt/bodyguard.svg)](https://hex.pm/packages/bodyguard)
+[![License](https://img.shields.io/hexpm/l/bodyguard.svg)](https://github.com/schrockwell/bodyguard/blob/master/LICENSE)
+[![Last Updated](https://img.shields.io/github/last-commit/schrockwell/bodyguard.svg)](https://github.com/schrockwell/bodyguard/commits/master)
 
 Bodyguard protects the context boundaries of your application. 💪
 
@@ -196,7 +202,8 @@ Here is the default library config.
 
 ```elixir
 config :bodyguard,
-  default_error: :unauthorized # The second element of the {:error, reason} tuple returned on auth failure
+  # The second element of the {:error, reason} tuple returned on auth failure
+  default_error: :unauthorized
 ```
 
 ## Testing
@@ -218,27 +225,29 @@ assert %{status: 403, message: "not authorized"} = error
 
 ## Installation
 
-1. Add `bodyguard` to your list of dependencies:
+1.  Add `:bodyguard` to your list of dependencies:
 
-```elixir
-# mix.exs
-def deps do
-  [{:bodyguard, "~> 2.4"}]
-end
-```
+    ```elixir
+    # mix.exs
+    def deps do
+      [
+        {:bodyguard, "~> 2.4"}
+      ]
+    end
+    ```
 
-2. Create an error view for handling `403 Forbidden`.
+2.  Create an error view for handling `403 Forbidden`.
 
-```elixir
-# lib/my_app_web/views/error_view.ex
-defmodule MyAppWeb.ErrorView do
-  use MyAppWeb, :view
+    ```elixir
+    # lib/my_app_web/views/error_view.ex
+    defmodule MyAppWeb.ErrorView do
+      use MyAppWeb, :view
 
-  def render("403.html", _assigns) do
-    "Forbidden"
-  end
-end
-```
+      def render("403.html", _assigns) do
+        "Forbidden"
+      end
+    end
+    ```
 
 3. Wire up a [fallback controller](#controllers) to render this error view on `{:error, :unauthorized}`.
 

--- a/lib/bodyguard.ex
+++ b/lib/bodyguard.ex
@@ -1,6 +1,6 @@
 defmodule Bodyguard do
   @moduledoc """
-  Authorize actions at the boundary of a context
+  Authorize actions at the boundary of a context.
 
   Please see the [README](readme.html).
   """

--- a/lib/bodyguard/action.ex
+++ b/lib/bodyguard/action.ex
@@ -30,7 +30,7 @@ defmodule Bodyguard.Action do
         use MyApp.Web, :controller
         import Bodyguard.Action
         alias MyApp.Blog
-        
+
         action_fallback MyApp.FallbackController
         plug Bodyguard.Plug.BuildAction, context: Blog, user: &get_current_user/1
 
@@ -56,8 +56,8 @@ defmodule Bodyguard.Action do
       |> put_policy(Blog.SomeSpecialPolicy)
       |> assign(:drafts, true)
       |> authorize(:list_posts)
-      |> put_job(fn action -> 
-        Blog.list_posts(action.user, drafts_only: action.assigns.drafts) 
+      |> put_job(fn action ->
+        Blog.list_posts(action.user, drafts_only: action.assigns.drafts)
       end)
       |> put_fallback(fn _action -> {:error, :not_found} end)
       |> run()

--- a/mix.exs
+++ b/mix.exs
@@ -1,23 +1,20 @@
 defmodule Bodyguard.Mixfile do
   use Mix.Project
 
+  @source_url "https://github.com/schrockwell/bodyguard"
+  @version "2.4.1"
+
   def project do
     [
       app: :bodyguard,
-      version: "2.4.1",
+      version: @version,
       elixir: "~> 1.3",
+      name: "Bodyguard",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       deps: deps(),
-      description: description(),
-      package: package(),
-
-      # Docs
-      name: "Bodyguard",
-      docs: [
-        extras: ["README.md"],
-        main: "readme"
-      ]
+      docs: docs(),
+      package: package()
     ]
   end
 
@@ -28,7 +25,7 @@ defmodule Bodyguard.Mixfile do
   defp deps do
     [
       {:plug, "~> 1.0"},
-      {:ex_doc, "~> 0.21", only: :dev},
+      {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
       {:mix_test_watch, "~> 1.0", only: :dev, runtime: false}
     ]
   end
@@ -43,11 +40,23 @@ defmodule Bodyguard.Mixfile do
   defp package do
     [
       name: :bodyguard,
+      description: description(),
       maintainers: ["Rockwell Schrock", "Ben Cates"],
       licenses: ["MIT"],
       links: %{
-        "GitHub" => "https://github.com/schrockwell/bodyguard"
+        "Changelog" => "https://hexdocs.pm/bodyguard/changelog.html",
+        "GitHub" => @source_url
       }
+    ]
+  end
+
+  defp docs do
+    [
+      extras: ["CHANGELOG.md", "README.md"],
+      main: "readme",
+      source_url: @source_url,
+      source_ref: "v#{@version}",
+      formatters: ["html"]
     ]
   end
 end


### PR DESCRIPTION
Besides other documentation changes, this commit ensures the generated
HTML doc for HexDocs.pm will become the main source doc for this Elixir
library which leverage on latest ExDoc features.