### PR TITLE
Fix docs for Bodyguard.scope

### DIFF
--- a/lib/bodyguard.ex
+++ b/lib/bodyguard.ex
@@ -98,7 +98,7 @@ defmodule Bodyguard do
       end
 
   If `params` is a keyword list, it is converted to a map before passing down
-  to the `c:Bodyguard.Policy.authorize/3` callback. Otherwise, `params` is not
+  to the `c:Bodyguard.Schema.scope/3` callback. Otherwise, `params` is not
   changed.
 
   #### Options


### PR DESCRIPTION
Noticed what looks like a copy & paste error while reading the docs.
I think `Bodyguard.Policy.authorize` should be `Bodyguard.Schema.scope` in docs for `Bodyguard.scope`.