### PR TITLE
Feature/default error runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 # Bodyguard Changelog
 
+## Unreleased
+* **Fix:** get default_error configuration at runtime
+
 ## v2.4.0
 
 * **Addition:** Adding ability to specify `{module, function}` for plug's value getters

--- a/lib/bodyguard.ex
+++ b/lib/bodyguard.ex
@@ -171,13 +171,15 @@ defmodule Bodyguard do
       #{inspect(unknown)} - specify the :schema option"
   end
 
-  @default_error Application.get_env(:bodyguard, :default_error, :unauthorized)
+  defp default_error do
+    Application.get_env(:bodyguard, :default_error, :unauthorized)
+  end
 
   # Coerce auth results
   defp resolve_result(true), do: :ok
   defp resolve_result(:ok), do: :ok
-  defp resolve_result(false), do: {:error, @default_error}
-  defp resolve_result(:error), do: {:error, @default_error}
+  defp resolve_result(false), do: {:error, default_error}
+  defp resolve_result(:error), do: {:error, default_error}
   defp resolve_result({:error, reason}), do: {:error, reason}
   defp resolve_result(invalid), do: raise("Unexpected authorization result: #{inspect(invalid)}")
 end


### PR DESCRIPTION
If you set this to a non-default value, you must recompile the application for it to take affect. Our builds were failing on CI as they cached the compiled files and only updated on changes to mix.lock. 