### PR TITLE
action type definition improvement

### DIFF
--- a/lib/bodyguard/policy.ex
+++ b/lib/bodyguard/policy.ex
@@ -37,7 +37,7 @@ defmodule Bodyguard.Policy do
 
   """
 
-  @type action :: atom | String.t()
+  @type action :: atom | String.t() | {module(), atom()}
   @type auth_result :: :ok | :error | {:error, reason :: any} | true | false
 
   @doc """


### PR DESCRIPTION
Hi, firstly, thanks for awesome work!

I do like to expand the type definition of the action type a little. 
I use policies tided to the controller/action, and I do that, configuring bodyguard to call a module/func to retrieve the current controller/action.
It's working pretty nicely, but after I bumped one of my projects to elixir 1.18, elixir-ls starts complaining about the expected type in the `authorize` callback.
![image](https://github.com/user-attachments/assets/e40d5518-1395-4145-94e1-581f3264ea9c)

Maybe, we can change it to any(), but IMHO, it's not necessary because any() make type specs too lazy.